### PR TITLE
Revert "Auto-update roswell"

### DIFF
--- a/roswell/README.md
+++ b/roswell/README.md
@@ -8,18 +8,15 @@
 ```
 $ docker pull fukamachi/roswell
 $ docker run -it --rm fukamachi/roswell
-$ docker pull fukamachi/roswell:21.06.14.110
-$ docker run -it --rm fukamachi/roswell:21.06.14.110
+$ docker pull fukamachi/roswell:21.05.14.109
+$ docker run -it --rm fukamachi/roswell:21.05.14.109
 ```
 
 ## Supported tags
 
-- `21.10.14.111`, `21.10.14.111-debian`, `latest`, `latest-debian`
-- `21.10.14.111-ubuntu`, `latest-ubuntu`
-- `21.10.14.111-alpine`, `latest-alpine`
-- `21.06.14.110`, `21.06.14.110-debian`
-- `21.06.14.110-alpine`
-- `21.06.14.110-ubuntu`
+- `21.06.14.110`, `21.06.14.110-debian`, `latest`, `latest-debian`
+- `21.06.14.110-ubuntu`, `latest-ubuntu`
+- `21.06.14.110-alpine`, `latest-alpine`
 - `21.05.14.109`, `21.05.14.109-debian`
 - `21.05.14.109-alpine`
 - `21.05.14.109-ubuntu`
@@ -45,5 +42,5 @@ $ docker run -it --rm fukamachi/roswell:21.06.14.110
 ## Building by your own
 
 ```
-$ docker build -t roswell:21.06.14.110 --build-arg VERSION=21.06.14.110 roswell/debian/
+$ docker build -t roswell:21.05.14.109 --build-arg VERSION=21.05.14.109 roswell/debian/
 ```

--- a/roswell/versions
+++ b/roswell/versions
@@ -6,4 +6,3 @@
 21.01.14.108,buster-slim,3.14,20.04,libcurl4-gnutls-dev
 21.05.14.109,buster-slim,3.14,20.04,libcurl4-gnutls-dev
 21.06.14.110,buster-slim,3.14,20.04,libcurl4-gnutls-dev
-21.10.14.111,bullseye-slim,3.14,20.04,libcurl4-gnutls-dev


### PR DESCRIPTION
Reverts fukamachi/dockerfiles#32 because it didn't create ARM64 images.